### PR TITLE
feat!: upgrade hydrogen, remove beta flag

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": [{"name": "main", "channel": "beta"}]
+  "branches": ["main"]
 }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # hydrogen-sanity
 
-> **Warning**
->
-> Please be advised that `hydrogen-sanity` is still under development and available in pre-release. This package could change before it's officially released, so check back for updates and please provide any feedback you might have here.
-
-[Sanity.io](https://www.sanity.io) toolkit for [Hydrogen](https://hydrogen.shopify.dev/)
+[Sanity.io](https://www.sanity.io) toolkit for [Hydrogen](https://hydrogen.shopify.dev/). Requires `@shopify/hydrogen >= 2023.7.0`.
 
 **Features:**
 
@@ -18,15 +14,15 @@
 ## Installation
 
 ```sh
-npm install hydrogen-sanity@beta
+npm install hydrogen-sanity
 ```
 
 ```sh
-yarn add hydrogen-sanity@beta
+yarn add hydrogen-sanity
 ```
 
 ```sh
-pnpm install hydrogen-sanity@beta
+pnpm install hydrogen-sanity
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sanity/pkg-utils": "^2.3.3",
         "@sanity/plugin-kit": "^3.1.7",
         "@sanity/semantic-release-preset": "^4.1.1",
-        "@shopify/hydrogen": "^2023.7.0",
+        "@shopify/hydrogen": "~2023.7.0",
         "@shopify/remix-oxygen": "^1.1.1",
         "@types/react": "^18.2.14",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -44,7 +44,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@shopify/hydrogen": "^2023.7.0",
+        "@shopify/hydrogen": "~2023.7.0",
         "@shopify/remix-oxygen": "^1.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sanity/pkg-utils": "^2.3.3",
         "@sanity/plugin-kit": "^3.1.7",
         "@sanity/semantic-release-preset": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.6",
+        "@shopify/hydrogen": "^2023.7.0",
         "@shopify/remix-oxygen": "^1.1.1",
         "@types/react": "^18.2.14",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -44,7 +44,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@shopify/hydrogen": "^2023.4.0",
+        "@shopify/hydrogen": "^2023.7.0",
         "@shopify/remix-oxygen": "^1.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -3239,21 +3239,28 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.18.1.tgz",
-      "integrity": "sha512-E0sQlgUQG2ytFmUH7zRH7n2MufnP6WWWq1KpRoiuwJZxfTFIzaiCCIiNqbP/uXGWDGcwEevpawNUzzszL1tT0w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
+      "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.7.1",
-        "@types/cookie": "^0.4.1",
+        "@remix-run/router": "1.6.3",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.4.1",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/@remix-run/router": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
+      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rexxars/choosealicense-list": {
@@ -5054,23 +5061,23 @@
       }
     },
     "node_modules/@shopify/hydrogen": {
-      "version": "2023.4.6",
-      "resolved": "https://registry.npmjs.org/@shopify/hydrogen/-/hydrogen-2023.4.6.tgz",
-      "integrity": "sha512-mX9iaEJV7dAEJMx0dQKHal6FkbK0aJ8pWjM8VsmK7wolXagL2EK6JyqbH9TdCJeXx0AJRqFLKkSL+OM67NgbLw==",
+      "version": "2023.7.0",
+      "resolved": "https://registry.npmjs.org/@shopify/hydrogen/-/hydrogen-2023.7.0.tgz",
+      "integrity": "sha512-c8DMoJMpXF6JdNhWBWR+tjQRtGeYrp0Ss+l0iGJtWrsJ/5I1sL4f5Rg6Pm4qrpmKAtVc0z/i/fLtlqPbw3wtkw==",
       "dev": true,
       "dependencies": {
-        "@shopify/hydrogen-react": "2023.4.5",
+        "@shopify/hydrogen-react": "2023.7.0",
         "react": "^18.2.0"
       },
       "peerDependencies": {
         "@remix-run/react": "^1.17.1",
-        "@remix-run/server-runtime": "^1.17.1"
+        "@remix-run/server-runtime": "1.17.1"
       }
     },
     "node_modules/@shopify/hydrogen-react": {
-      "version": "2023.4.5",
-      "resolved": "https://registry.npmjs.org/@shopify/hydrogen-react/-/hydrogen-react-2023.4.5.tgz",
-      "integrity": "sha512-A/8vi2UHBURmp7IJANmadDBdfiBsOL6wmNTBKUNbz0HSn4P7XdkQijkXMpcW/BEzaoZlFiZnyCOKJZGr8bqe4Q==",
+      "version": "2023.7.0",
+      "resolved": "https://registry.npmjs.org/@shopify/hydrogen-react/-/hydrogen-react-2023.7.0.tgz",
+      "integrity": "sha512-MlOBWCKNNsPREce3C0mzqj1wWLvdNzbNZSNnfL8QTNEjSr+hhmb4wjogNJjo6nX1w4x21MmpIOZWV9OdI4eX/g==",
       "dev": true,
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -5107,31 +5114,6 @@
         "@shopify/oxygen-workers-types": "^3.17.2"
       }
     },
-    "node_modules/@shopify/remix-oxygen/node_modules/@remix-run/router": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.3.tgz",
-      "integrity": "sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@shopify/remix-oxygen/node_modules/@remix-run/server-runtime": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.17.1.tgz",
-      "integrity": "sha512-PuLDaf7WmrOaQzM70yCcM6Jm+g+UHzeBFvocxdqohJnO/8+/n5pFIKHwhooqcSq2TR0WtVpSVhCakdywiOH2mA==",
-      "dev": true,
-      "dependencies": {
-        "@remix-run/router": "1.6.3",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.4.1",
-        "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -5161,13 +5143,6 @@
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@sanity/pkg-utils": "^2.3.3",
     "@sanity/plugin-kit": "^3.1.7",
     "@sanity/semantic-release-preset": "^4.1.1",
-    "@shopify/hydrogen": "^2023.4.6",
+    "@shopify/hydrogen": "^2023.7.0",
     "@shopify/remix-oxygen": "^1.1.1",
     "@types/react": "^18.2.14",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -83,7 +83,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@shopify/hydrogen": "^2023.4.0",
+    "@shopify/hydrogen": "^2023.7.0",
     "@shopify/remix-oxygen": "^1.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@sanity/pkg-utils": "^2.3.3",
     "@sanity/plugin-kit": "^3.1.7",
     "@sanity/semantic-release-preset": "^4.1.1",
-    "@shopify/hydrogen": "^2023.7.0",
+    "@shopify/hydrogen": "~2023.7.0",
     "@shopify/remix-oxygen": "^1.1.1",
     "@types/react": "^18.2.14",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
@@ -83,7 +83,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@shopify/hydrogen": "^2023.7.0",
+    "@shopify/hydrogen": "~2023.7.0",
     "@shopify/remix-oxygen": "^1.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import {
   type SanityClient,
 } from '@sanity/preview-kit/client'
 // eslint-disable-next-line camelcase
-import {CacheLong, createWithCache_unstable} from '@shopify/hydrogen'
+import {CacheLong, createWithCache} from '@shopify/hydrogen'
 
 import type {PreviewSession} from './preview'
 import type {CachingStrategy, EnvironmentOptions} from './types'
@@ -44,7 +44,7 @@ export function createSanityClient(options: CreateSanityClientOptions): Sanity {
     client: createClient(config),
     async query<T = any>({query, params, cache: strategy = CacheLong()}: useSanityQuery) {
       const queryHash = await hashQuery(query, params)
-      const withCache = createWithCache_unstable<T>({
+      const withCache = createWithCache<T>({
         cache,
         waitUntil,
       })


### PR DESCRIPTION
This PR upgrades to the latest version of Hydrogen, and removes the `_unstable` suffix from the `createWithCache` function now it's out of beta.

It also removes the beta flag from the `.releaserc.json` to move the package out of beta.