### PR TITLE
fix: add return types

### DIFF
--- a/src/preview/PreviewProvider.tsx
+++ b/src/preview/PreviewProvider.tsx
@@ -34,7 +34,7 @@ export function PreviewProvider(props: SanityPreviewProps): ReactElement {
   useEffect(() => startTransition(() => setHydrated(true)), [])
 
   if (!hydrated || !previewConfig || !previewConfig.projectId) {
-    return <>children</>
+    return <>{children}</>
   }
 
   const client = createClient(previewConfig)

--- a/src/preview/PreviewProvider.tsx
+++ b/src/preview/PreviewProvider.tsx
@@ -1,7 +1,15 @@
 /* eslint-disable react/require-default-props */
 import type {LiveQueryProviderProps} from '@sanity/preview-kit'
 import {type ClientConfig, createClient} from '@sanity/preview-kit/client'
-import {lazy, type ReactNode, Suspense, useEffect, useState, useTransition} from 'react'
+import {
+  lazy,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+  useEffect,
+  useState,
+  useTransition,
+} from 'react'
 
 import {PreviewContext} from './context'
 
@@ -18,7 +26,7 @@ type SanityPreviewProps = Omit<LiveQueryProviderProps, 'client'> & {
  * TODO: inline documentation
  * @see https://www.sanity.io/docs/preview-content-on-site
  */
-export function PreviewProvider(props: SanityPreviewProps) {
+export function PreviewProvider(props: SanityPreviewProps): ReactElement {
   const {children, previewConfig, fallback = children, ...rest} = props
 
   const [, startTransition] = useTransition()
@@ -26,7 +34,7 @@ export function PreviewProvider(props: SanityPreviewProps) {
   useEffect(() => startTransition(() => setHydrated(true)), [])
 
   if (!hydrated || !previewConfig || !previewConfig.projectId) {
-    return children
+    return <>children</>
   }
 
   const client = createClient(previewConfig)

--- a/src/preview/SanityPreview.tsx
+++ b/src/preview/SanityPreview.tsx
@@ -23,7 +23,7 @@ export function SanityPreview<T = unknown>(props: PreviewProps<T>): ReactElement
   const isPreview = Boolean(usePreviewContext())
 
   if (typeof children !== 'function') {
-    return <>children</>
+    return <>{children}</>
   }
 
   if (isPreview && query) {

--- a/src/preview/SanityPreview.tsx
+++ b/src/preview/SanityPreview.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/require-default-props */
 import type {QueryParams} from '@sanity/client'
 import {useLiveQuery} from '@sanity/preview-kit'
-import {type ReactNode} from 'react'
+import {type ReactElement, type ReactNode} from 'react'
 
 import {usePreviewContext} from './context'
 
@@ -18,12 +18,12 @@ type PreviewProps<T> = {
  * When provided a Sanity query and render prop,
  * changes will be streamed in the client
  */
-export function SanityPreview<T = unknown>(props: PreviewProps<T>) {
+export function SanityPreview<T = unknown>(props: PreviewProps<T>): ReactElement {
   const {data, children, query, params} = props
   const isPreview = Boolean(usePreviewContext())
 
   if (typeof children !== 'function') {
-    return children
+    return <>children</>
   }
 
   if (isPreview && query) {


### PR DESCRIPTION
Currently there are TS errors on Hydrogen front-ends. This fixes it by declaring a return type on the relevant components.