### PR TITLE
fix: update dependencies `@sanity/client` and `@sanity/preview-kit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@sanity/client": "^6.8.0",
-        "@sanity/preview-kit": "^3.2.7"
+        "@sanity/client": "^6.15.17",
+        "@sanity/preview-kit": "^5.0.45"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.1",
@@ -3707,13 +3707,12 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.8.0.tgz",
-      "integrity": "sha512-SshNs8WfL3PxStBLqgq5FZJAmJO/Nj2IPynPYa+ze+h4SUZU6L/LyIj6848C91nHABICocuUJ3gwZRhK6YNNdw==",
+      "version": "6.15.17",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.15.17.tgz",
+      "integrity": "sha512-wttOq7OcSGQ87Noisohy5uE2bY3/J22k6gnHz1YwLCsmX92xxBlvSYr5h7QvNZMNO8rJnlIBXJiX48IZxYJGvg==",
       "dependencies": {
         "@sanity/eventsource": "^5.0.0",
-        "@vercel/stega": "0.1.0",
-        "get-it": "^8.4.4",
+        "get-it": "^8.4.26",
         "rxjs": "^7.0.0"
       },
       "engines": {
@@ -3729,25 +3728,6 @@
         "@types/eventsource": "1.1.12",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
-      }
-    },
-    "node_modules/@sanity/groq-store": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-4.1.3.tgz",
-      "integrity": "sha512-Yh3zbCkpnrowIG8+tMoZHGxV9HFMWVlZ4zhNfF1Y2rygi14SJteV+ildrlq3/OFq9/Y/cc6iXSD/+U6dErIpNw==",
-      "dependencies": {
-        "@sanity/eventsource": "^5.0.0",
-        "@sanity/types": "^3.14.5",
-        "fast-deep-equal": "3.1.3",
-        "groq": "^3.14.5",
-        "groq-js": "1.3.0",
-        "mendoza": "3.0.3",
-        "simple-get": "4.0.1",
-        "split2": "4.2.0",
-        "throttle-debounce": "5.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@sanity/pkg-utils": {
@@ -4086,25 +4066,18 @@
       }
     },
     "node_modules/@sanity/preview-kit": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-kit/-/preview-kit-3.2.7.tgz",
-      "integrity": "sha512-NxTq7+l4Tetuevh6Y28in7+yGUuXyTW+N4InlsUk2l82GYDwWMVhyF/ugh2bbHs6SJU7FWZigsKxW9o+a+L3mw==",
+      "version": "5.0.45",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-kit/-/preview-kit-5.0.45.tgz",
+      "integrity": "sha512-2tkZr4rJYaPG39iMnM55cjMUNPzFo22IIT7JB+bbKhc9k/GoP8zn+clMNW974TWv+gQ4RQcxFvqzwWUJb0qkaw==",
       "dependencies": {
-        "@sanity/eventsource": "5.0.1",
-        "@sanity/groq-store": "4.1.3",
-        "@vercel/stega": "0.1.0",
-        "lodash.get": "4.4.2",
-        "lodash.isplainobject": "4.0.6",
-        "lru-cache": "10.0.1",
-        "mendoza": "3.0.3",
-        "react-fast-compare": "3.2.2",
-        "use-sync-external-store": "1.2.0"
+        "@sanity/preview-kit-compat": "1.4.17",
+        "mendoza": "3.0.7"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.7.1",
+        "@sanity/client": "^6.15.17",
         "react": "^18.0.0"
       },
       "peerDependenciesMeta": {
@@ -4113,12 +4086,16 @@
         }
       }
     },
-    "node_modules/@sanity/preview-kit/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+    "node_modules/@sanity/preview-kit-compat": {
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-kit-compat/-/preview-kit-compat-1.4.17.tgz",
+      "integrity": "sha512-zDW/IcsTyROGDKEjixHWTwhnkDZGcqcEL0eu4H/jJ0G5wxMPtxtzSCzAafCKuUgSsiybxBRpjo2h6tjm9/AUIA==",
       "engines": {
-        "node": "14 || >=16.14"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.15.17",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@sanity/semantic-release-preset": {
@@ -4138,15 +4115,6 @@
       },
       "peerDependencies": {
         "semantic-release": "^22.0.5"
-      }
-    },
-    "node_modules/@sanity/types": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.19.2.tgz",
-      "integrity": "sha512-kTT/+G8yLYZAnauxANrQxxW9QRYt33Mv6xDu4IHcvmFDOXzZLtW6tazOuSwgkMzBSpl8PCkU4fKSGU2myRf7SA==",
-      "dependencies": {
-        "@sanity/client": "^6.7.0",
-        "@types/react": "^18.0.25"
       }
     },
     "node_modules/@semantic-release/changelog": {
@@ -5060,12 +5028,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.10",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
-      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A=="
+      "integrity": "sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.37",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
       "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5081,7 +5051,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.6.tgz",
-      "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA=="
+      "integrity": "sha512-Vlktnchmkylvc9SnwwwozTv04L/e1NykF5vgoQ0XTmI8DD+wxfjQuHuvHS3p0r2jz2x2ghPs2h1FVeDirIteWA==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.5",
@@ -5288,11 +5259,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
-    },
-    "node_modules/@vercel/stega": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.0.tgz",
-      "integrity": "sha512-5b0PkOJsFBX5alChuIO3qpkt5vIZBevzLPhUQ1UP8UzVjL3F1VllnZxp/thfD8R5ol7D7WHkgZHIjdUBX4tDpQ=="
     },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
@@ -6557,7 +6523,8 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -6588,6 +6555,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -7796,7 +7764,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -8002,9 +7971,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -8179,18 +8148,15 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.4.tgz",
-      "integrity": "sha512-Pu3pnJfnYuLEhwJgMlFqk19ugvtazzTxh7rg8wATaBL4c5Fy4ahM5B+bGdluiNSNYYK89F5vSa+N3sTa/qqtlg==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.26.tgz",
+      "integrity": "sha512-cl5R5+auJcBw7Qm9eZ+mVRRhU3e5H65pqkBqlaJmU85HI8C91F9CE/rmj4U23+Fz3GLD2uT0W+312rbH/T8IJA==",
       "dependencies": {
-        "debug": "^4.3.4",
         "decompress-response": "^7.0.0",
-        "follow-redirects": "^1.15.2",
+        "follow-redirects": "^1.15.6",
         "into-stream": "^6.0.0",
-        "is-plain-object": "^5.0.0",
         "is-retry-allowed": "^2.2.0",
         "is-stream": "^2.0.1",
-        "parse-headers": "^2.0.5",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -8631,22 +8597,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/groq": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.19.2.tgz",
-      "integrity": "sha512-IR+AbjW3rTB9gklB/DasQyChLGyYUvs7QcRg44oONpMnth4fVRvanPF4LH6NKQkTt86s6CsZaB/poijwZ3YaAA==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/groq-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-1.3.0.tgz",
-      "integrity": "sha512-J7+JcxM0OvoowSkhNZAabCLueldEMkKzd9ufCEDRjKvkD1PcBUwyfsGvxUI59UojRCqFqp0y76LLzPzwSZTetw==",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/handlebars": {
@@ -9438,6 +9388,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10305,7 +10257,8 @@
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -10322,7 +10275,8 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
@@ -10682,9 +10636,9 @@
       }
     },
     "node_modules/mendoza": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.3.tgz",
-      "integrity": "sha512-xh0Angj7/kuLzJHglH7dVetoSyUt1/2wjmuugB0iBftteS6+xKvwC+bhs+IvF9tITdEdZpIl0XT5QLaL18A5dA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.7.tgz",
+      "integrity": "sha512-KtLgsCl5dFjRPUVSVV9KxpUr2BfZgLv8uqxg/hCsI7JIWsesHABSbl0MQwxNHAg24KtzSQ6vrPsgeNnoq4UImg==",
       "engines": {
         "node": ">=14.18"
       }
@@ -10859,7 +10813,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -14468,6 +14423,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -14834,11 +14790,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -15415,11 +15366,6 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -16845,63 +16791,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-get/node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -17116,6 +17005,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -17506,14 +17396,6 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
       "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg==",
       "dev": true
-    },
-    "node_modules/throttle-debounce": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
-      "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
-      "engines": {
-        "node": ">=12.22"
-      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -18002,6 +17884,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -18227,7 +18110,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@sanity/client": "^6.8.0",
-    "@sanity/preview-kit": "^3.2.7"
+    "@sanity/client": "^6.15.17",
+    "@sanity/preview-kit": "^5.0.45"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,7 +7,7 @@ import {
   type RawQueryResponse,
   type SanityClient,
   type UnfilteredResponseQueryOptions,
-} from '@sanity/preview-kit/client'
+} from '@sanity/client'
 import {CacheLong, createWithCache} from '@shopify/hydrogen'
 
 import type {CachingStrategy, EnvironmentOptions, SessionLike} from './types'

--- a/src/preview/PreviewProvider.tsx
+++ b/src/preview/PreviewProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
+import {type ClientConfig, createClient} from '@sanity/client'
 import type {LiveQueryProviderProps} from '@sanity/preview-kit'
-import {type ClientConfig, createClient} from '@sanity/preview-kit/client'
 import {
   lazy,
   type ReactElement,


### PR DESCRIPTION
Fixes an issue where Hydrogen storefronts using `vite` encountered CommonJS syntax