### PR TITLE
Update README.md

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -52,7 +52,7 @@ pnpm install hydrogen-sanity
 Update the server file to include the Sanity Loader, and optionally, configure the preview mode if you plan to setup Visual Editing
 
 ```ts
-// ./server.ts
+// ./app/lib/context.ts
 
 // ...all other imports
 // Add imports for Sanity Loader and Preview Session


### PR DESCRIPTION
Hi!

The reference to server.ts in the usage section is misleading. The `cache` and `waitUntil` is now located in `createAppLoadContext` in `./app/lib/context.ts`. This PR makes it more clear.