### PR TITLE
feat: deprecate 'loader' in favor of 'context'

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -52,7 +52,7 @@ pnpm install hydrogen-sanity
 Update the server file to include the Sanity Loader, and optionally, configure the preview mode if you plan to setup Visual Editing
 
 > [!NOTE]
-> The examples below are up-to-date as of `2024.7.10`
+> The examples below are up-to-date as of `npm create @shopify/hydrogen@2024.7.10`
 
 ```ts
 // ./lib/context.ts

--- a/package/README.md
+++ b/package/README.md
@@ -429,7 +429,7 @@ export async function createAppLoadContext(
   const sanity = createClient({
     projectId: env.SANITY_PROJECT_ID,
     dataset: env.SANITY_DATASET,
-    apiVersion: env.SANITY_API_VERSION ?? '2023-03-30',
+    apiVersion: env.SANITY_API_VERSION ?? 'v2024-08-08',
     useCdn: process.env.NODE_ENV === 'production',
   })
 

--- a/package/README.md
+++ b/package/README.md
@@ -51,6 +51,9 @@ pnpm install hydrogen-sanity
 
 Update the server file to include the Sanity Loader, and optionally, configure the preview mode if you plan to setup Visual Editing
 
+> [!NOTE]
+> The examples below are up-to-date as of `2024.7.10`
+
 ```ts
 // ./lib/context.ts
 
@@ -73,7 +76,7 @@ export async function createAppLoadContext(
   const sanity = createSanityContext({
     request,
 
-    // Caching mechanism
+    // To use the Hydrogen cache for queries
     cache,
     waitUntil,
 

--- a/package/src/context.test.ts
+++ b/package/src/context.test.ts
@@ -1,13 +1,39 @@
 import type {QueryStore} from '@sanity/react-loader'
-import {CacheShort, createWithCache} from '@shopify/hydrogen'
+import {CacheShort, WithCache} from '@shopify/hydrogen'
 import groq from 'groq'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createClient, SanityClient} from './client'
-import {createSanityLoader} from './loader'
+import {createSanityContext} from './context'
 import {hashQuery} from './utils'
 
+// Mock the global caches object
+const cache = vi.hoisted<Cache>(() => ({
+  add: vi.fn().mockResolvedValue(undefined),
+  addAll: vi.fn().mockResolvedValue(undefined),
+  delete: vi.fn().mockResolvedValue(true),
+  keys: vi.fn().mockResolvedValue([]),
+  match: vi.fn().mockResolvedValue(undefined),
+  matchAll: vi.fn().mockResolvedValue([]),
+  put: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock the Sanity loader
 const loadQuery = vi.hoisted<QueryStore['loadQuery']>(() => vi.fn().mockResolvedValue(null))
+
+let withCache = vi.hoisted<WithCache | null>(() => null)
+
+vi.mock('@shopify/hydrogen', async (importOriginal) => {
+  const module = await importOriginal<typeof import('@shopify/hydrogen')>()
+  withCache = vi
+    .fn()
+    .mockImplementation(module.createWithCache({cache, waitUntil: () => Promise.resolve()}))
+
+  return {
+    ...module,
+    createWithCache: vi.fn().mockReturnValue(withCache),
+  }
+})
 
 vi.mock('@sanity/react-loader', async (importOriginal) => {
   const module = await importOriginal<typeof import('@sanity/react-loader')>()
@@ -22,24 +48,6 @@ vi.mock('@sanity/react-loader', async (importOriginal) => {
   }
 })
 
-// Mock the global caches object
-const cache: Cache = {
-  add: vi.fn().mockResolvedValue(undefined),
-  addAll: vi.fn().mockResolvedValue(undefined),
-  delete: vi.fn().mockResolvedValue(true),
-  keys: vi.fn().mockResolvedValue([]),
-  match: vi.fn().mockResolvedValue(undefined),
-  matchAll: vi.fn().mockResolvedValue([]),
-  put: vi.fn().mockResolvedValue(undefined),
-}
-
-function waitUntil() {
-  return Promise.resolve()
-}
-
-type WithCache = ReturnType<typeof createWithCache>
-const withCache: WithCache = vi.fn().mockImplementation(createWithCache({cache, waitUntil}))
-
 const client = createClient({projectId: 'my-project-id', dataset: 'my-dataset'})
 
 const query = groq`true`
@@ -50,38 +58,44 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('the loader', () => {
-  const loader = createSanityLoader({withCache, client})
+describe('the Sanity request context', () => {
+  const request = new Request('https://example.com')
+  const sanityContext = createSanityContext({request, cache, client})
 
   it('should return a client', () => {
-    expect(loader.client).toSatisfy((loaderClient) => loaderClient instanceof SanityClient)
+    expect(sanityContext.client).toSatisfy((contextClient) => contextClient instanceof SanityClient)
   })
 
   it('queries should get cached using the default caching strategy', async () => {
-    const strategy = CacheShort()
+    const defaultStrategy = CacheShort()
 
-    const loaderWithDefaultStrategy = createSanityLoader({
-      withCache,
+    const contextWithDefaultStrategy = createSanityContext({
+      request,
+      cache,
       client,
-      strategy,
+      defaultStrategy,
     })
 
-    await loaderWithDefaultStrategy.loadQuery<boolean>(query, params)
-    expect(withCache).toHaveBeenCalledWith(hashedQuery, strategy, expect.any(Function))
+    await contextWithDefaultStrategy.loadQuery<boolean>(query, params)
+    expect(withCache).toHaveBeenCalledWith(hashedQuery, defaultStrategy, expect.any(Function))
     expect(cache.put).toHaveBeenCalled()
   })
 
   it('queries should use the cache strategy passed in `loadQuery`', async () => {
     const strategy = CacheShort()
-    await loader.loadQuery<boolean>(query, params, {hydrogen: {cache: strategy}})
+    await sanityContext.loadQuery<boolean>(query, params, {
+      hydrogen: {cache: strategy},
+    })
     expect(withCache).toHaveBeenCalledWith(hashedQuery, strategy, expect.any(Function))
     expect(cache.put).toHaveBeenCalled()
   })
 })
 
 describe('when configured for preview', () => {
-  const previewLoader = createSanityLoader({
-    withCache,
+  const request = new Request('https://example.com')
+  const previewContext = createSanityContext({
+    request,
+    cache,
     client,
     preview: {
       enabled: true,
@@ -93,24 +107,24 @@ describe('when configured for preview', () => {
   it('should throw if a token is not provided', () => {
     expect(() =>
       // @ts-expect-error meant to test invalid configuration
-      createSanityLoader({cache, waitUntil, client, preview: {enabled: true}}),
+      createSanityContext({client, preview: {enabled: true}}),
     ).toThrowErrorMatchingInlineSnapshot(`[Error: Enabling preview mode requires a token.]`)
   })
 
   it.todo(`shouldn't use API CDN`, () => {
-    expect(previewLoader.client.config().useCdn).toBe(false)
+    expect(previewContext.client.config().useCdn).toBe(false)
   })
 
   it.todo('should use the `previewDrafts` perspective', () => {
-    expect(previewLoader.client.config().perspective).toBe('previewDrafts')
+    expect(previewContext.client.config().perspective).toBe('previewDrafts')
   })
 
   it('should enable preview mode', () => {
-    expect(previewLoader.preview?.enabled).toBe(true)
+    expect(previewContext.preview?.enabled).toBe(true)
   })
 
   it(`shouldn't cache queries`, async () => {
-    await previewLoader.loadQuery<boolean>(query)
+    await previewContext.loadQuery<boolean>(query)
     expect(loadQuery).toHaveBeenCalledOnce()
     expect(cache.put).not.toHaveBeenCalled()
   })

--- a/package/src/context.ts
+++ b/package/src/context.ts
@@ -1,11 +1,5 @@
 import {loadQuery, type QueryResponseInitial, setServerClient} from '@sanity/react-loader'
-import {
-  CacheLong,
-  CacheNone,
-  type CachingStrategy,
-  createWithCache,
-  type HydrogenSession,
-} from '@shopify/hydrogen'
+import {CacheLong, CacheNone, type CachingStrategy, createWithCache} from '@shopify/hydrogen'
 
 import {
   type ClientConfig,
@@ -88,16 +82,6 @@ export type SanityContext = {
   client: SanityClient
 
   preview?: CreateSanityContextOptions['preview']
-}
-
-declare module '@shopify/remix-oxygen' {
-  /**
-   * Declare local additions to the Remix loader context.
-   */
-  export interface AppLoadContext {
-    session: HydrogenSession
-    sanity: SanityContext
-  }
 }
 
 /**

--- a/package/src/context.ts
+++ b/package/src/context.ts
@@ -1,4 +1,4 @@
-import {createQueryStore, type QueryResponseInitial} from '@sanity/react-loader'
+import {loadQuery, type QueryResponseInitial, setServerClient} from '@sanity/react-loader'
 import {
   CacheLong,
   CacheNone,
@@ -100,8 +100,6 @@ declare module '@shopify/remix-oxygen' {
   }
 }
 
-const queryStore = createQueryStore({client: false, ssr: true})
-
 /**
  * @public
  */
@@ -134,9 +132,9 @@ export function createSanityContext(options: CreateSanityContextOptions): Sanity
       },
     })
 
-    queryStore.setServerClient(previewClient)
+    setServerClient(previewClient)
   } else {
-    queryStore.setServerClient(client)
+    setServerClient(client)
   }
 
   const sanity = {
@@ -164,9 +162,9 @@ export function createSanityContext(options: CreateSanityContextOptions): Sanity
               })
             }
 
-            return await queryStore.loadQuery<T>(query, params, loaderOptions)
+            return await loadQuery<T>(query, params, loaderOptions)
           })
-        : queryStore.loadQuery<T>(query, params, loaderOptions))
+        : loadQuery<T>(query, params, loaderOptions))
     },
     client,
     preview,

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client'
+export {createSanityContext, type SanityContext} from './context'
 export {createSanityLoader, type SanityLoader} from './loader'
 // TODO: add default session?

--- a/package/src/loader.ts
+++ b/package/src/loader.ts
@@ -1,4 +1,4 @@
-import {createQueryStore, type QueryResponseInitial} from '@sanity/react-loader'
+import {loadQuery, type QueryResponseInitial, setServerClient} from '@sanity/react-loader'
 import {
   CacheLong,
   CacheNone,
@@ -99,8 +99,6 @@ declare module '@shopify/remix-oxygen' {
   }
 }
 
-const queryStore = createQueryStore({client: false, ssr: true})
-
 /**
  * @deprecated Use `createSanityContext` instead
  */
@@ -132,9 +130,9 @@ export function createSanityLoader(options: CreateSanityLoaderOptions): SanityLo
       },
     })
 
-    queryStore.setServerClient(previewClient)
+    setServerClient(previewClient)
   } else {
-    queryStore.setServerClient(client)
+    setServerClient(client)
   }
 
   const sanity = {
@@ -162,7 +160,7 @@ export function createSanityLoader(options: CreateSanityLoaderOptions): SanityLo
           })
         }
 
-        return await queryStore.loadQuery<T>(query, params, loaderOptions)
+        return await loadQuery<T>(query, params, loaderOptions)
       })
     },
     client,

--- a/package/src/loader.ts
+++ b/package/src/loader.ts
@@ -1,11 +1,5 @@
 import {loadQuery, type QueryResponseInitial, setServerClient} from '@sanity/react-loader'
-import {
-  CacheLong,
-  CacheNone,
-  type CachingStrategy,
-  type HydrogenSession,
-  type WithCache,
-} from '@shopify/hydrogen'
+import {CacheLong, CacheNone, type CachingStrategy, type WithCache} from '@shopify/hydrogen'
 
 import {
   type ClientConfig,
@@ -87,16 +81,6 @@ export type SanityLoader = {
   client: SanityClient
 
   preview?: CreateSanityLoaderOptions['preview']
-}
-
-declare module '@shopify/remix-oxygen' {
-  /**
-   * Declare local additions to the Remix loader context.
-   */
-  export interface AppLoadContext {
-    session: HydrogenSession
-    sanity: SanityLoader
-  }
 }
 
 /**

--- a/package/src/preview/route.ts
+++ b/package/src/preview/route.ts
@@ -1,5 +1,9 @@
 import {validatePreviewUrl} from '@sanity/preview-url-secret'
+import type {HydrogenSession} from '@shopify/hydrogen'
 import {type ActionFunction, json, type LoaderFunction, redirect} from '@shopify/remix-oxygen'
+
+import type {SanityContext} from '../context'
+import {assertSession} from '../utils'
 
 /**
  * A `POST` request to this route will exit preview mode
@@ -9,48 +13,70 @@ export const action: ActionFunction = async ({context, request}) => {
     return json({message: 'Method not allowed'}, 405)
   }
 
-  // TODO: make this a callback? `onExitPreview`?
-  await context.session.unset('projectId')
+  try {
+    const {session} = context
+    if (!assertSession(session)) {
+      throw new Error('Session is not an instance of HydrogenSession')
+    }
 
-  // TODO: confirm that the redirect and setting cookie has to happen here?
-  return redirect('/', {
-    headers: {
-      'Set-Cookie': await context.session.commit(),
-    },
-  })
+    // TODO: make this a callback? `onExitPreview`?
+    await session.unset('projectId')
+
+    // TODO: confirm that the redirect and setting cookie has to happen here?
+    return redirect('/')
+  } catch (error) {
+    console.error(error)
+    throw new Response('Unable to disable preview mode. Please check your preview configuration', {
+      status: 500,
+    })
+  }
 }
 
 /**
  * A `GET` request to this route will enter preview mode
  */
 export const loader: LoaderFunction = async ({context, request}) => {
-  const {sanity} = context
-  const projectId = sanity.client.config().projectId
+  try {
+    // TODO: to remove
+    const {sanity, session} = context as {sanity: SanityContext; session: HydrogenSession}
+    const projectId = sanity.client.config().projectId
 
-  if (!sanity.preview?.token || !projectId) {
+    if (!sanity.preview) {
+      return new Response('Preview mode is not enabled in this environment.', {status: 403})
+    }
+
+    if (!sanity.preview.token) {
+      throw new Error('Enabling preview mode requires a token.')
+    }
+
+    if (!projectId) {
+      throw new Error('No `projectId` found in the client config.')
+    }
+
+    if (!assertSession(session)) {
+      throw new Error('Session is not an instance of HydrogenSession')
+    }
+
+    const clientWithToken = sanity.client.withConfig({
+      useCdn: false,
+      token: sanity.preview.token,
+    })
+
+    const {isValid, redirectTo = '/'} = await validatePreviewUrl(clientWithToken, request.url)
+
+    if (!isValid) {
+      return new Response('Invalid secret', {status: 401})
+    }
+
+    // TODO: make this a callback? `onEnterPreview`?
+    await session.set('projectId', projectId)
+
+    // TODO: confirm that the redirect and setting cookie has to happen here?
+    return redirect(redirectTo)
+  } catch (error) {
+    console.error(error)
     throw new Response('Unable to enable preview mode. Please check your preview configuration', {
       status: 500,
     })
   }
-
-  const clientWithToken = sanity.client.withConfig({
-    useCdn: false,
-    token: sanity.preview.token,
-  })
-
-  const {isValid, redirectTo = '/'} = await validatePreviewUrl(clientWithToken, request.url)
-
-  if (!isValid) {
-    throw new Response('Invalid secret', {status: 401})
-  }
-
-  // TODO: make this a callback? `onEnterPreview`?
-  await context.session.set('projectId', projectId)
-
-  // TODO: confirm that the redirect and setting cookie has to happen here?
-  return redirect(redirectTo, {
-    headers: {
-      'Set-Cookie': await context.session.commit(),
-    },
-  })
 }

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -1,3 +1,5 @@
+import type {HydrogenSession} from '@shopify/hydrogen'
+
 import type {QueryParams, QueryWithoutParams} from './client'
 
 /**
@@ -30,4 +32,19 @@ export function hashQuery(
   }
 
   return sha256(hash)
+}
+
+export function assertSession(session: unknown): session is HydrogenSession {
+  return (
+    !!session &&
+    typeof session === 'object' &&
+    'get' in session &&
+    typeof session.get === 'function' &&
+    'set' in session &&
+    typeof session.set === 'function' &&
+    'unset' in session &&
+    typeof session.unset === 'function' &&
+    'commit' in session &&
+    typeof session.commit === 'function'
+  )
 }

--- a/package/vitest.config.ts
+++ b/package/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineProject({
     isolate: false,
     setupFiles: ['./vitest.setup.ts'],
     // Enable rich PR failed test annotation on the CI
-    // eslint-disable-next-line no-process-env
     reporters: process.env.GITHUB_ACTIONS ? ['default', new GithubActionsReporter()] : 'default',
   },
 })


### PR DESCRIPTION
- feat: deprecate 'loader' in favor of 'context'
- docs: update defult API version
- docs: add version callout
- fix: don't create query store
- fix: add better error messages in preview route