### PR TITLE
fix(deps): allow studio v4 in peer dep ranges + main.yml update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,11 +120,20 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -133,15 +142,6 @@ jobs:
       - run: pnpm install
         # Branches that will release new versions are defined in .releaserc.json
       - run: pnpm --filter="hydrogen-sanity" run release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        # Re-run semantic release with rich logs if it failed to publish for easier debugging
-      - run: pnpm --filter="hydrogen-sanity" run release:debug
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package/package.json
+++ b/package/package.json
@@ -112,10 +112,10 @@
     "vitest-github-actions-reporter": "^0.11.1"
   },
   "peerDependencies": {
-    "@sanity/client": "^6.18.0",
+    "@sanity/client": "^6.18.0 || ^7.0.0",
     "@shopify/hydrogen": "^2023.7.0 || ~2024.1.0 || ~2024.4.0 || ~2024.7.0 || ~2024.10.0 || ~2025.1.0",
     "@shopify/remix-oxygen": "^1.0.0 || ^2.0.0",
-    "groq": "^3.41.0",
+    "groq": "^3.41.0 || ^4.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
  └── ✕ unmet peer groq@^3.41.0: found 4.0.0-0
Done in 10s using pnpm v10.12.1
```
This fixes it.

I've also bumped the client package version

### Testing

Tested it by doing a canary release with the changes needed and checking the deps. Everything words as expected.
