### PR TITLE
Use `@sanity/visual-editing`'s React Router build for `next` branch

### DIFF
--- a/packages/hydrogen-sanity/src/visual-editing/VisualEditing.client.tsx
+++ b/packages/hydrogen-sanity/src/visual-editing/VisualEditing.client.tsx
@@ -1,4 +1,4 @@
-import {VisualEditing} from '@sanity/visual-editing/remix'
+import {VisualEditing} from '@sanity/visual-editing/react-router'
 
 /**
  * Prevent a consumer from importing into a worker/server bundle.

--- a/packages/hydrogen-sanity/src/visual-editing/VisualEditing.tsx
+++ b/packages/hydrogen-sanity/src/visual-editing/VisualEditing.tsx
@@ -1,4 +1,4 @@
-import type {VisualEditingProps} from '@sanity/visual-editing/remix'
+import type {VisualEditingProps} from '@sanity/visual-editing/react-router'
 import {lazy, type ReactElement, Suspense} from 'react'
 
 /**


### PR DESCRIPTION
### Description

`hydrogen-sanity` v5 is meant for Hydrogen's migration to React Router v7. The Remix build of `@sanity/visual-editing` is incompatible.

Changes `@sanity/visual-editing/remix` imports to `@sanity/visual-editing/react-router`.