### PR TITLE
chore: update branch references after renaming main→v4 and next→main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
       - 'packages/hydrogen-sanity/**'
   # Build on commits pushed to branches without a PR if it's in the allowlist
   push:
-    branches: [main, beta, next]
+    branches: [main, beta, v4, next]
     paths:
       - 'packages/hydrogen-sanity/**'
   # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -3,7 +3,7 @@ name: Deploy Sanity Studio
 on:
   push:
     branches:
-      - next
+      - main
     paths:
       - 'examples/studio/**'
       - 'packages/sanity-config/**'
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'workflow_dispatch'
 
     environment:
-      name: ${{ github.event_name == 'workflow_dispatch' && 'Production' || github.ref == 'refs/heads/next' && 'Production' || 'Preview' }}
+      name: ${{ github.event_name == 'workflow_dispatch' && 'Production' || github.ref == 'refs/heads/main' && 'Production' || 'Preview' }}
       url: ${{ steps.deploy.outputs.STUDIO_URL }}
 
     env:

--- a/packages/hydrogen-sanity/release.config.mjs
+++ b/packages/hydrogen-sanity/release.config.mjs
@@ -5,11 +5,6 @@ export default {
       name: 'main',
       channel: 'latest',
     },
-    // {
-    //   name: 'v4',
-    //   channel: 'v4',
-    //   range: '^4.0.0',
-    // },
     {
       name: 'beta',
       prerelease: true,
@@ -17,6 +12,11 @@ export default {
     {
       name: 'next',
       prerelease: true,
+    },
+    {
+      name: 'v4',
+      channel: 'v4',
+      range: '^4.0.0',
     },
   ],
 }


### PR DESCRIPTION
## Summary
- Updates branch references in CI workflows and semantic-release config after branch renaming
- Changes CI workflow to include new branch structure: `[main, beta, v4, next]`
- Updates Studio deployment to trigger on `main` instead of `next`
- Updates semantic-release config to handle both `v4` (stable) and `next` (prerelease) branches

## Branch Renaming Changes
- `main` branch renamed to `v4` (for legacy releases)
- `next` branch renamed to `main` (new default branch)

## Test plan
- [ ] Verify CI workflow triggers on correct branches
- [ ] Verify Studio deployment works on `main` branch  
- [ ] Verify semantic-release configuration is correct

🤖 Generated with [Claude Code](https://claude.ai/code)