### PR TITLE
Add new Hydrogen 2025.7.0 peer dependency

### DIFF
--- a/packages/hydrogen-sanity/package.json
+++ b/packages/hydrogen-sanity/package.json
@@ -132,7 +132,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^7",
-    "@shopify/hydrogen": "~2025.5.0",
+    "@shopify/hydrogen": "~2025.5.0 || ~2025.7.0",
     "react": "^18.2.0",
     "react-router": "7.6.0",
     "vite": "^5.1.0 || ^6.2.1"


### PR DESCRIPTION
### Description

Shopify just released a new version of Hydrogen `2.7.0`, so we need to update this dependency in order to properly `npm install` this package with a hydrogen project.

### What to review

Make sure the dependency update is correctly updated to include the new Hydrogen version.
