### PR TITLE
Use NODE_AUTH_TOKEN instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Publish to NPM with provenance
       - name: Publish to NPM
-        run: pnpm --filter="hydrogen-sanity" publish --provenance --access public
+        run: pnpm --filter="hydrogen-sanity" publish --tag next --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/packages/hydrogen-sanity/package.json
+++ b/packages/hydrogen-sanity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrogen-sanity",
-  "version": "5.1.1",
+  "version": "5.1.1-next.0",
   "description": "Sanity.io toolkit for Hydrogen",
   "keywords": [
     "sanity",


### PR DESCRIPTION
### Description

npm won't correctly detect `NPM_TOKEN` unless it's specifically mapped via a `.npmrc` file. This PR swaps the `NPM_TOKEN` variable name for `NODE_AUTH_TOKEN` which should be correctly detected by npm.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
