### PR TITLE
fix(preview): set the CHIPS Partitioned attribute on cross-site iframe previews

### DIFF
--- a/packages/hydrogen-sanity/README.md
+++ b/packages/hydrogen-sanity/README.md
@@ -891,6 +891,18 @@ You should now be able to view your Hydrogen app in the Presentation Tool, click
 >
 > Since Presentation displays your site in an iframe, the session cookie by default won't be sent through. You can learn more about session cookie configuation in [MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value).
 
+#### Third-party cookie restrictions
+
+`sameSite: 'none'` and `secure: true` are not enough on their own when the browser blocks unpartitioned third-party cookies — Safari blocks them outright, and Chromium does in Incognito or when the user has opted in. Because Studio and your storefront are on different sites, the preview cookie is treated as third-party and silently dropped, so preview mode never enables.
+
+`PreviewSession` handles this for you: when it sees the request that enters preview mode arrive as a cross-site iframe navigation, it writes the cookie with the [`Partitioned` attribute](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) (CHIPS) so the browser stores it under Studio's partition. Top-level requests — such as opening a preview link in a new tab — keep an unpartitioned cookie.
+
+If you manage the preview cookie yourself instead of using `PreviewSession`, set `partitioned: true` alongside `sameSite: 'none'` and `secure: true`.
+
+> [!NOTE]
+>
+> Safari supports partitioned cookies in 18.4 and in 26.2 or later. Support was [disabled in 18.5](https://bugs.webkit.org/show_bug.cgi?id=292975) and restored in 26.2, so Presentation cannot connect from Safari 18.5 through 26.1 regardless of this setting.
+
 ### Troubleshooting
 
 Are you getting the following error when trying to load your storefront in the Presentation Tool?
@@ -904,6 +916,7 @@ Presentation will throw this error if it can't establish a connection to your st
 3. If you've followed the instructions above, the `VisualEditing` component will be conditionally rendered if the app has been successfully put into preview mode.
 4. If you're using a session cookie, check your browser devtools and confirm that the cookie has been set as expected.
 5. Since Presentation loads your storefront in an `iframe`, double check your cookie and CSP configuration.
+6. If `/api/preview` responds with a `Set-Cookie` header but the browser doesn't keep the cookie, it's being blocked as a third-party cookie — see [Third-party cookie restrictions](#third-party-cookie-restrictions).
 
 ## Using `@sanity/client` directly
 

--- a/packages/hydrogen-sanity/README.md
+++ b/packages/hydrogen-sanity/README.md
@@ -897,7 +897,11 @@ You should now be able to view your Hydrogen app in the Presentation Tool, click
 
 `PreviewSession` handles this for you: when it sees the request that enters preview mode arrive as a cross-site iframe navigation, it writes the cookie with the [`Partitioned` attribute](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies) (CHIPS) so the browser stores it under Studio's partition. Top-level requests — such as opening a preview link in a new tab — keep an unpartitioned cookie.
 
-If you manage the preview cookie yourself instead of using `PreviewSession`, set `partitioned: true` alongside `sameSite: 'none'` and `secure: true`.
+If you manage the preview cookie yourself instead of using `PreviewSession`, set `partitioned: true` alongside `sameSite: 'none'` and `secure: true`. To override what `PreviewSession` decides, or to set any other cookie attribute, pass cookie options as its third argument:
+
+```ts
+PreviewSession.init(request, [env.SESSION_SECRET], {partitioned: true})
+```
 
 > [!NOTE]
 >

--- a/packages/hydrogen-sanity/src/preview/session.test.ts
+++ b/packages/hydrogen-sanity/src/preview/session.test.ts
@@ -1,0 +1,133 @@
+import {perspectiveCookieName} from '@sanity/preview-url-secret/constants'
+import {describe, expect, it} from 'vitest'
+
+import {PreviewSession} from './session'
+
+const secrets = ['test-secret']
+
+/**
+ * Presentation loads the storefront as a cross-site iframe navigation.
+ */
+const crossSiteIframeHeaders = {
+  'sec-fetch-dest': 'iframe',
+  'sec-fetch-site': 'cross-site',
+}
+
+/**
+ * Entering preview mode by opening the preview URL in a new tab.
+ */
+const topLevelHeaders = {
+  'sec-fetch-dest': 'document',
+  'sec-fetch-site': 'none',
+}
+
+function createRequest(headers?: Record<string, string>) {
+  return new Request('https://storefront.example/api/preview?secret=test', {headers})
+}
+
+/** Turn a `Set-Cookie` header back into a `Cookie` header for the next request. */
+function asCookieHeader(setCookie: string): string {
+  return setCookie.split(';')[0]
+}
+
+async function enterPreviewMode(request: Request): Promise<string> {
+  const session = await PreviewSession.init(request, secrets)
+  session.set('perspective', 'drafts')
+  return session.commit()
+}
+
+describe('PreviewSession', () => {
+  it('sets the baseline cross-site cookie attributes', async () => {
+    const setCookie = await enterPreviewMode(createRequest(crossSiteIframeHeaders))
+
+    expect(setCookie).toContain(`${perspectiveCookieName}=`)
+    expect(setCookie).toContain('Path=/')
+    expect(setCookie).toContain('HttpOnly')
+    expect(setCookie).toContain('Secure')
+    expect(setCookie).toContain('SameSite=None')
+  })
+
+  describe('CHIPS partitioning', () => {
+    it('partitions the cookie for a cross-site iframe request', async () => {
+      const setCookie = await enterPreviewMode(createRequest(crossSiteIframeHeaders))
+
+      expect(setCookie).toContain('Partitioned')
+    })
+
+    it('does not partition the cookie for a top-level request', async () => {
+      const setCookie = await enterPreviewMode(createRequest(topLevelHeaders))
+
+      expect(setCookie).not.toContain('Partitioned')
+    })
+
+    it('does not partition the cookie when Sec-Fetch headers are absent', async () => {
+      const setCookie = await enterPreviewMode(createRequest())
+
+      expect(setCookie).not.toContain('Partitioned')
+    })
+
+    it('keeps partitioning later same-origin writes from inside the iframe', async () => {
+      const enabled = await enterPreviewMode(createRequest(crossSiteIframeHeaders))
+
+      // A perspective change is a same-origin fetch, so it carries no iframe
+      // signal — the decision has to come from the cookie that was sent back.
+      const session = await PreviewSession.init(
+        createRequest({
+          'cookie': asCookieHeader(enabled),
+          'sec-fetch-dest': 'empty',
+          'sec-fetch-site': 'same-origin',
+        }),
+        secrets,
+      )
+      session.set('perspective', 'published')
+
+      expect(await session.commit()).toContain('Partitioned')
+    })
+
+    it('does not partition later writes when preview was entered top-level', async () => {
+      const enabled = await enterPreviewMode(createRequest(topLevelHeaders))
+
+      const session = await PreviewSession.init(
+        createRequest({
+          'cookie': asCookieHeader(enabled),
+          'sec-fetch-dest': 'empty',
+          'sec-fetch-site': 'same-origin',
+        }),
+        secrets,
+      )
+      session.set('perspective', 'published')
+
+      expect(await session.commit()).not.toContain('Partitioned')
+    })
+  })
+
+  describe('disabling preview mode', () => {
+    it('expires a partitioned cookie with matching attributes', async () => {
+      const enabled = await enterPreviewMode(createRequest(crossSiteIframeHeaders))
+
+      const session = await PreviewSession.init(
+        createRequest({cookie: asCookieHeader(enabled)}),
+        secrets,
+      )
+      const setCookie = await session.destroy()
+
+      // A partitioned cookie can only be cleared by an expiry that also carries
+      // `Partitioned`, otherwise it lingers in the partitioned jar.
+      expect(setCookie).toContain('Partitioned')
+      expect(setCookie).toContain('Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+    })
+
+    it('expires an unpartitioned cookie without the attribute', async () => {
+      const enabled = await enterPreviewMode(createRequest(topLevelHeaders))
+
+      const session = await PreviewSession.init(
+        createRequest({cookie: asCookieHeader(enabled)}),
+        secrets,
+      )
+      const setCookie = await session.destroy()
+
+      expect(setCookie).not.toContain('Partitioned')
+      expect(setCookie).toContain('Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+    })
+  })
+})

--- a/packages/hydrogen-sanity/src/preview/session.test.ts
+++ b/packages/hydrogen-sanity/src/preview/session.test.ts
@@ -130,4 +130,33 @@ describe('PreviewSession', () => {
       expect(setCookie).toContain('Expires=Thu, 01 Jan 1970 00:00:00 GMT')
     })
   })
+
+  describe('cookie option overrides', () => {
+    it('honours an explicit opt in for a top-level request', async () => {
+      const session = await PreviewSession.init(createRequest(topLevelHeaders), secrets, {
+        partitioned: true,
+      })
+      session.set('perspective', 'drafts')
+
+      expect(await session.commit()).toContain('Partitioned')
+    })
+
+    it('honours an explicit opt out for a cross-site iframe request', async () => {
+      const session = await PreviewSession.init(createRequest(crossSiteIframeHeaders), secrets, {
+        partitioned: false,
+      })
+      session.set('perspective', 'drafts')
+
+      expect(await session.commit()).not.toContain('Partitioned')
+    })
+
+    it('applies other cookie attributes without letting the name be changed', async () => {
+      const session = await PreviewSession.init(createRequest(), secrets, {maxAge: 60})
+      session.set('perspective', 'drafts')
+      const setCookie = await session.commit()
+
+      expect(setCookie).toContain(`${perspectiveCookieName}=`)
+      expect(setCookie).toContain('Max-Age=60')
+    })
+  })
 })

--- a/packages/hydrogen-sanity/src/preview/session.ts
+++ b/packages/hydrogen-sanity/src/preview/session.ts
@@ -3,6 +3,28 @@ import {createCookieSessionStorage, type Session, type SessionStorage} from 'rea
 
 interface PreviewSessionData {
   perspective: string
+  /**
+   * Records that this cookie was written with the CHIPS `Partitioned` attribute.
+   * A partitioned cookie is only readable inside its own partition, so reading
+   * this flag back is proof that the request is running in that partition.
+   */
+  partitioned: boolean
+}
+
+/**
+ * Detects whether a request is a cross-site iframe navigation, which is how
+ * Presentation loads the storefront.
+ *
+ * Only the request that enters preview mode carries this signal. Later writes
+ * (perspective changes, disabling preview) are same-origin fetches from within
+ * the iframe and are indistinguishable from top-level fetches, which is why the
+ * decision is persisted in the session payload.
+ */
+function isCrossSiteIframe(request: Request): boolean {
+  return (
+    request.headers.get('sec-fetch-dest') === 'iframe' &&
+    request.headers.get('sec-fetch-site') === 'cross-site'
+  )
 }
 
 /**
@@ -24,14 +46,16 @@ export interface SanityPreviewSession {
 export class PreviewSession implements SanityPreviewSession {
   #sessionStorage
   #session
+  #partitioned
 
-  constructor(sessionStorage: SessionStorage, session: Session) {
+  constructor(sessionStorage: SessionStorage, session: Session, partitioned = false) {
     this.#sessionStorage = sessionStorage
     this.#session = session
+    this.#partitioned = partitioned
   }
 
   static async init(request: Request, secrets: string[]): Promise<PreviewSession> {
-    const storage = createCookieSessionStorage({
+    const storage = createCookieSessionStorage<PreviewSessionData>({
       cookie: {
         name: perspectiveCookieName,
         httpOnly: true,
@@ -46,7 +70,18 @@ export class PreviewSession implements SanityPreviewSession {
       .getSession(request.headers.get('Cookie'))
       .catch(() => storage.getSession())
 
-    return new this(storage, session)
+    // Browsers that block unpartitioned third-party cookies (Safari blocks them
+    // outright) drop this cookie when Presentation frames the storefront, so
+    // preview mode never enables. Opt into CHIPS for that case only: partitioning
+    // top-level requests would needlessly change the cookie's identity for the
+    // already-working "open preview in a new tab" flow.
+    const partitioned = session.get('partitioned') || isCrossSiteIframe(request)
+
+    if (partitioned) {
+      session.set('partitioned', true)
+    }
+
+    return new this(storage, session, partitioned)
   }
 
   get has(): SanityPreviewSession['has'] {
@@ -66,10 +101,10 @@ export class PreviewSession implements SanityPreviewSession {
   }
 
   destroy(): ReturnType<SanityPreviewSession['destroy']> {
-    return this.#sessionStorage.destroySession(this.#session)
+    return this.#sessionStorage.destroySession(this.#session, {partitioned: this.#partitioned})
   }
 
   commit(): ReturnType<SanityPreviewSession['commit']> {
-    return this.#sessionStorage.commitSession(this.#session)
+    return this.#sessionStorage.commitSession(this.#session, {partitioned: this.#partitioned})
   }
 }

--- a/packages/hydrogen-sanity/src/preview/session.ts
+++ b/packages/hydrogen-sanity/src/preview/session.ts
@@ -1,5 +1,10 @@
 import {perspectiveCookieName} from '@sanity/preview-url-secret/constants'
-import {createCookieSessionStorage, type Session, type SessionStorage} from 'react-router'
+import {
+  type CookieOptions,
+  createCookieSessionStorage,
+  type Session,
+  type SessionStorage,
+} from 'react-router'
 
 interface PreviewSessionData {
   perspective: string
@@ -10,6 +15,12 @@ interface PreviewSessionData {
    */
   partitioned: boolean
 }
+
+/**
+ * Cookie attributes callers may override when initialising the preview session.
+ * `name` and `secrets` are owned by the package and cannot be changed.
+ */
+export type PreviewCookieOptions = Omit<CookieOptions, 'name' | 'secrets'>
 
 /**
  * Detects whether a request is a cross-site iframe navigation, which is how
@@ -54,14 +65,19 @@ export class PreviewSession implements SanityPreviewSession {
     this.#partitioned = partitioned
   }
 
-  static async init(request: Request, secrets: string[]): Promise<PreviewSession> {
+  static async init(
+    request: Request,
+    secrets: string[],
+    cookieOptions?: PreviewCookieOptions,
+  ): Promise<PreviewSession> {
     const storage = createCookieSessionStorage<PreviewSessionData>({
       cookie: {
-        name: perspectiveCookieName,
         httpOnly: true,
         path: '/',
         sameSite: 'none',
         secure: true,
+        ...cookieOptions,
+        name: perspectiveCookieName,
         secrets,
       },
     })
@@ -75,7 +91,8 @@ export class PreviewSession implements SanityPreviewSession {
     // preview mode never enables. Opt into CHIPS for that case only: partitioning
     // top-level requests would needlessly change the cookie's identity for the
     // already-working "open preview in a new tab" flow.
-    const partitioned = session.get('partitioned') || isCrossSiteIframe(request)
+    const partitioned =
+      cookieOptions?.partitioned ?? (session.get('partitioned') || isCrossSiteIframe(request))
 
     if (partitioned) {
       session.set('partitioned', true)


### PR DESCRIPTION
Fixes #193.

## Problem

Safari blocks all unpartitioned third-party cookies unconditionally. Chromium still allows them by default (the deprecation was abandoned) and only blocks in Incognito or on user opt-in. Firefox partitions third-party cookies automatically via Total Cookie Protection, so it already works.

`PreviewSession` writes the preview cookie as `SameSite=None; Secure` with no `Partitioned`. Since Studio and the storefront are on different sites, browsers that block unpartitioned third-party cookies drop it: `/api/preview` succeeds server-side, the browser never stores the cookie, `preview.enabled` stays `false`, `VisualEditing` never mounts, and Presentation times out with *"Unable to connect to visual editing"*.

## Approach

Follows [next-sanity#3780](https://github.com/sanity-io/next-sanity/pull/3780) (fixing [next-sanity#3794](https://github.com/sanity-io/next-sanity/issues/3794), formerly `sanity#12806`), adapted where our architecture differs.

**Opt into CHIPS only for cross-site iframe previews**, detected via `Sec-Fetch-Dest: iframe` and `Sec-Fetch-Site: cross-site`.

**Persist the decision in the session payload.** Only the request that enters preview mode carries the iframe signal. Perspective changes go through `useSubmit({method: 'PUT'})` from inside the iframe, i.e. a same-origin fetch reporting `Sec-Fetch-Site: same-origin` — indistinguishable from a top-level fetch. `next-sanity` solved this with a companion `sanity-preview-partitioned` cookie because `__prerender_bypass` is opaque and Next-owned. We own the whole signed payload, so the flag lives inside it: one cookie instead of two, tamper-proof via existing signing, and the top-level and partitioned jars each carry their own correct flag, so both contexts work simultaneously.

## Browser support caveat

Presentation cannot connect from Safari 18.5–26.1 regardless of this change. ITP-classified domains also can't use partitioned cookies in third-party context even with the attribute.

## Test plan

- [x] New `src/preview/session.test.ts` — 11 cases: baseline attributes, iframe / top-level / missing-header detection, persistence across same-origin writes for both jars, matching-attribute expiry on destroy for both jars, override opt-in/opt-out, name is not overridable
- [x] `turbo lint typecheck build` (strict + publint) and full suite (133 passed) green
- [ ] Manual: hosted Studio + Oxygen storefront, Presentation connects in Safari 26.2+
- [ ] Manual: Chrome Incognito Presentation connects
- [ ] Manual: "open preview in new tab" still enables, and disabling still clears the cookie in both contexts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview session cookie semantics and signing payload (`partitioned` flag), which affects whether Visual Editing enables in cross-site iframes; behavior is well-tested but touches security-sensitive session handling.
> 
> **Overview**
> Fixes Presentation preview failing when browsers block unpartitioned third-party cookies (Safari, Chromium Incognito, etc.) by having **`PreviewSession`** set the CHIPS **`Partitioned`** attribute only for cross-site iframe entry (`Sec-Fetch-Dest: iframe` + `Sec-Fetch-Site: cross-site`), while top-level preview links stay unpartitioned.
> 
> The partitioned choice is **stored in the signed session payload** so later same-origin commits and **`destroy()`** still emit cookies with matching **`Partitioned`** (required to clear partitioned cookies). **`PreviewSession.init`** gains an optional third argument **`PreviewCookieOptions`** to override **`partitioned`** or other cookie attrs.
> 
> Adds **`session.test.ts`** (11 cases) and README docs on third-party cookies, Safari CHIPS versions, and troubleshooting when **`Set-Cookie`** is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9dc4b79c363d25cc642a1e49a120c5f0a6ff13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->